### PR TITLE
fix sanitize falsy artists and works on saving application. Fix #27

### DIFF
--- a/app/server/methods/applicationMethods.js
+++ b/app/server/methods/applicationMethods.js
@@ -18,8 +18,12 @@ Meteor.methods({
 
     // Look for falsy values on works and remove them
     if (applicationUpdate.hasOwnProperty('$set') && applicationUpdate.$set.hasOwnProperty('artists')) {
+
+      // Sanitize artists
+      applicationUpdate.$set.artists = _.compact( applicationUpdate.$set.artists);
       for (var i = 0; i < applicationUpdate.$set.artists.length; i++) {
         if (applicationUpdate.$set.artists[i].hasOwnProperty('work')) {
+          // Sanitize works
           applicationUpdate.$set.artists[i].work = _.compact( applicationUpdate.$set.artists[i].work );
         }
       }


### PR DESCRIPTION
The problem when saving happened with both Artists and Works when the object had _null_ values at the beginning. Ex.

```
{
  "_id": "3wAYHvfC5w4anLxPx",
  "userId": "ppEnsSZWHbD9647fR",
  "status": "saved",
  "booth": "booth-extra",
  "artists": [
    null,
    {
      "work": [   
        null,
        {
          "workTitle": "Poops on canvas"
        }
      ]
    },
    {
      "name": "Artishta contemporaneo de la roma",
      "work": [
        {
          "workTitle": "A1W2"
        }
      ]
    }
  ]
}
```

The case where Artists had falsy values wasn't covered on previous fixes to this problem until now.

I should add that how an application ends up with falsy values is still unknown. I suspect of autoform and how it manages elimination of repeatable elements
