### PR TITLE
remove regex validation from website and email in application schema

### DIFF
--- a/app/lib/schemas.js
+++ b/app/lib/schemas.js
@@ -307,7 +307,6 @@ ApplicationSchema = new SimpleSchema({
   },
   website: {
     type: String,
-    regEx: SimpleSchema.RegEx.Domain,
     optional: true,
   },
 
@@ -317,7 +316,6 @@ ApplicationSchema = new SimpleSchema({
   },
   contactEmail: {
     type: String,
-    regEx: SimpleSchema.RegEx.Email,
   },
   contactPhone: {
     type: String,


### PR DESCRIPTION
allows for new TLDs like `.website`
